### PR TITLE
Adds Sublime default TABS prefs

### DIFF
--- a/roles/subl/tasks/main.yml
+++ b/roles/subl/tasks/main.yml
@@ -49,3 +49,8 @@
   git: repo="https://github.com/SublimeLinter/SublimeLinter3.git" dest="{{ subl_app_folder }}Packages/SublimeLinter" update=yes
   tags:
     - subl-packages
+
+# default user preferences
+- name: SublimePrefs
+  when: subl_exists|failed
+  copy: src="roles/subl/vars/Preferences.sublime-settings" dest="{{ home_dir }}/Library/Application Support/Sublime Text 3/Packages/User/Preferences.sublime-settings"

--- a/roles/subl/vars/Preferences.sublime-settings
+++ b/roles/subl/vars/Preferences.sublime-settings
@@ -1,0 +1,7 @@
+{
+  "color_scheme": "Packages/User/SublimeLinter/Monokai (SL).tmTheme",
+  // The number of spaces a tab is considered equal to
+  "tab_size": 2,
+  // Set to true to insert spaces when tab is pressed
+  "translate_tabs_to_spaces": true,
+}


### PR DESCRIPTION
Thought it would be helpful to add the preferred Sublime tab settings. I added the src file into ./roles/subl/vars which may or may not be best practice.
PS: It works and doesn't bork existing installations bc it checks for subl_exists like the other tasks do..